### PR TITLE
Add URL to start of Twitter links

### DIFF
--- a/electionkit.php
+++ b/electionkit.php
@@ -238,7 +238,7 @@ function np_sample_ballot(){
 													<a href="<?php echo $candidate->person->contact_facebook ?>" target="_blank">Facebook</a>
 												<?php } ?>
 												<?php if ($candidate->person->contact_twitter) { ?>
-													<a href="<?php echo $candidate->person->contact_twitter ?>" target="_blank">Twitter</a>
+													<a href="https://twitter.com/<?php echo $candidate->person->contact_twitter ?>" target="_blank">Twitter</a>
 												<?php } ?>
 											</div>
 										</div>


### PR DESCRIPTION
I noticed when testing that the Facebook links are full URLs, but the Twitter links are just returning usernames. 

I've added the Twitter URL in front of the username in this PR, but please close if that's not the right approach in this case -- thanks!