### PR TITLE
improvement: update ballot measure design, newspack case, result ux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /vendor/
 /node_modules/
 /dist/
-.DS_Store
 release
+.idea/
+yarn.lock

--- a/src/electionkit.js
+++ b/src/electionkit.js
@@ -2,7 +2,7 @@ import './electionkit.scss';
 
 ( $ => {
 	$( document ).ready( function() {
-		const ajax_object = window.ajax_object;
+		const { ajax_object } = window;
 		const $sampleBallot = $( '.newspack-electionkit .sample-ballot' );
 		const $spinner = $( '.newspack-electionkit .spinner' );
 		const $errorState = $( '.newspack-electionkit .ek-error' );
@@ -20,6 +20,7 @@ import './electionkit.scss';
 					show_bios: $( '.newspack-electionkit #ek-show-bio' ).val(),
 				},
 				beforeSend() {
+					$sampleBallot.fadeOut();
 					$spinner.toggleClass( 'is-active' );
 					$errorState.removeClass( 'is-active' );
 				},
@@ -29,6 +30,7 @@ import './electionkit.scss';
 					if ( response.success === true ) {
 						if ( response.data.ballot !== '' ) {
 							$sampleBallot.html( response.data.ballot );
+							$sampleBallot.show();
 						} else {
 							$errorState.toggleClass( 'is-active' );
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes the order of the ballot measures.
Places the ballot measures with the Ballotpedia district they appear, instead of the top of the ballot. (feature request from a newsroom).  The old location is still available.
PHP Code improvements based on WPCS and VIPCS
changes NewsPack to Newspack for branding on the form (feature request)
updated UX for sending in a second submission hides the previous result.

Closes #3 

### How to test the changes in this Pull Request:

1. Download new version, enter an address, and view the results

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
