### PR TITLE
feat: settings page with google api key field

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,7 @@
 
 Install using a shortcode ```[sample_ballot]```
 
-Has a dependency on Google API key for address.  Later versions will make it a WordPress option.
-
-## API Keys:
-
-This plugin requires a valid Google Maps Geocoding API key. You can obtain one for free following the instructions from [Google here](https://developers.google.com/maps/documentation/geocoding/start).
-
-Please add a line to `wp-config.php` providing this key, as follows:
-
-```
-define( 'NEWSPACK_ELECTIONKIT_GOOGLE_API_KEY', 'YOUR-GOOGLE-API-KEY' );
-```
+Has a dependency on Google API key for address, which can be set in Settings->Election Kit.
 
 ## Development
 

--- a/electionkit.php
+++ b/electionkit.php
@@ -55,7 +55,7 @@ add_shortcode( 'sample_ballot', 'np_sample_ballot_form' );
  */
 function np_sample_ballot() {
 	$election_date              = '2020-11-03';
-	$google_api_key             = defined( 'NEWSPACK_ELECTIONKIT_GOOGLE_API_KEY' ) ? NEWSPACK_ELECTIONKIT_GOOGLE_API_KEY : null;
+	$google_api_key             = get_option( 'newspack_electionkit_google_api_key', null );
 	$google_maps_api_url        = 'https://maps.googleapis.com/maps/api/geocode/json';
 	$bp_sample_ballot_elections = 'https://api4.ballotpedia.org/sample_ballot_elections';
 	$bp_sample_ballot_results   = 'https://api4.ballotpedia.org/myvote_results';
@@ -390,3 +390,8 @@ function np_electionkit_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'np_electionkit_scripts' );
 
+
+
+if ( ! class_exists( 'Newspack_Electionkit_Settings' ) ) {
+	include_once dirname( __FILE__ ) . '/includes/class-newspack-electionkit-settings.php';
+}

--- a/electionkit.php
+++ b/electionkit.php
@@ -54,8 +54,9 @@ add_shortcode( 'sample_ballot', 'np_sample_ballot_form' );
  * Generate sample ballot.
  */
 function np_sample_ballot() {
+	$google_maps_api_url_legacy = defined( 'NEWSPACK_ELECTIONKIT_GOOGLE_API_KEY' ) ? NEWSPACK_ELECTIONKIT_GOOGLE_API_KEY : null;
 	$election_date              = '2020-11-03';
-	$google_api_key             = get_option( 'newspack_electionkit_google_api_key', null );
+	$google_api_key             = get_option( 'newspack_electionkit_google_api_key', $google_maps_api_url_legacy );
 	$google_maps_api_url        = 'https://maps.googleapis.com/maps/api/geocode/json';
 	$bp_sample_ballot_elections = 'https://api4.ballotpedia.org/sample_ballot_elections';
 	$bp_sample_ballot_results   = 'https://api4.ballotpedia.org/myvote_results';

--- a/includes/class-newspack-electionkit-settings.php
+++ b/includes/class-newspack-electionkit-settings.php
@@ -71,7 +71,7 @@ class Newspack_Electionkit_Settings {
 		);
 		add_settings_field(
 			'newspack_electionkit_google_api_key',
-			__( 'Google Maps Geocoding API Key', 'newspack-electionkit' ),
+			__( 'Google Maps', 'newspack-electionkit' ),
 			[ __CLASS__, 'newspack_electionkit_google_api_key_callback' ],
 			'newspack-electionkit-settings-admin',
 			'newspack_electionkit_settings'
@@ -84,8 +84,9 @@ class Newspack_Electionkit_Settings {
 	public static function newspack_electionkit_google_api_key_callback() {
 		$newspack_electionkit_google_api_key = get_option( 'newspack_electionkit_google_api_key', false );
 		printf(
-			'<input type="text" id="newspack_electionkit_google_api_key" name="newspack_electionkit_google_api_key" value="%s" />',
-			esc_attr( $newspack_electionkit_google_api_key )
+			'<input type="text" id="newspack_electionkit_google_api_key" aria-describedby="newspack_electionkit_google_api_key-description" name="newspack_electionkit_google_api_key" value="%s" class="regular-text" /><p class="description" id="newspack_electionkit_google_api_key-description">%s</p>',
+			esc_attr( $newspack_electionkit_google_api_key ),
+			wp_kses_post( 'This plugin requires a valid Google Maps Geocoding API key. You can obtain one for free following the instructions from <a href="https://developers.google.com/maps/documentation/geocoding/start" target="_blank">Google here</a>.' )
 		);
 	}
 }

--- a/includes/class-newspack-electionkit-settings.php
+++ b/includes/class-newspack-electionkit-settings.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Newspack Election Kit Settings Page.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages Settings page.
+ */
+class Newspack_Electionkit_Settings {
+	/**
+	 * Set up hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_menu', [ __CLASS__, 'add_plugin_page' ] );
+		add_action( 'admin_init', [ __CLASS__, 'page_init' ] );
+	}
+
+	/**
+	 * Add options page
+	 */
+	public static function add_plugin_page() {
+		add_options_page(
+			__( 'Settings Admin', 'newspack-electionkit' ),
+			__( 'Election Kit', 'newspack-electionkit' ),
+			'manage_options',
+			'newspack-electionkit-settings-admin',
+			[ __CLASS__, 'create_admin_page' ]
+		);
+	}
+
+	/**
+	 * Options page callback
+	 */
+	public static function create_admin_page() {
+
+		?>
+		<div class="wrap">
+			<h1><?php _e( 'Election Kit Settings', 'newspack-electionkit' ); ?></h1>
+			<form method="post" action="options.php">
+			<?php
+				settings_fields( 'newspack_electionkit_options_group' );
+				do_settings_sections( 'newspack-electionkit-settings-admin' );
+				submit_button();
+			?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Register and add settings
+	 */
+	public static function page_init() {
+		register_setting(
+			'newspack_electionkit_options_group',
+			'newspack_electionkit_google_api_key'
+		);
+		add_settings_section(
+			'newspack_electionkit_settings',
+			__( 'API Keys', 'newspack-electionkit' ),
+			null,
+			'newspack-electionkit-settings-admin'
+		);
+		add_settings_field(
+			'newspack_electionkit_google_api_key',
+			__( 'Google Maps Geocoding API Key', 'newspack-electionkit' ),
+			[ __CLASS__, 'newspack_electionkit_google_api_key_callback' ],
+			'newspack-electionkit-settings-admin',
+			'newspack_electionkit_settings'
+		);
+	}
+
+	/**
+	 * Render Debug checkbox.
+	 */
+	public static function newspack_electionkit_google_api_key_callback() {
+		$newspack_electionkit_google_api_key = get_option( 'newspack_electionkit_google_api_key', false );
+		printf(
+			'<input type="text" id="newspack_electionkit_google_api_key" name="newspack_electionkit_google_api_key" value="%s" />',
+			esc_attr( $newspack_electionkit_google_api_key )
+		);
+	}
+}
+
+if ( is_admin() ) {
+	Newspack_Electionkit_Settings::init();
+}

--- a/includes/class-newspack-electionkit-settings.php
+++ b/includes/class-newspack-electionkit-settings.php
@@ -21,6 +21,9 @@ class Newspack_Electionkit_Settings {
 	public static function init() {
 		add_action( 'admin_menu', [ __CLASS__, 'add_plugin_page' ] );
 		add_action( 'admin_init', [ __CLASS__, 'page_init' ] );
+		if ( ! get_option( 'newspack_electionkit_google_api_key', null ) ) {
+			add_action( 'admin_notices', [ __CLASS__, 'activation_nag' ] );
+		}
 	}
 
 	/**
@@ -88,6 +91,25 @@ class Newspack_Electionkit_Settings {
 			esc_attr( $newspack_electionkit_google_api_key ),
 			wp_kses_post( 'This plugin requires a valid Google Maps Geocoding API key. You can obtain one for free following the instructions from <a href="https://developers.google.com/maps/documentation/geocoding/start" target="_blank">Google here</a>.' )
 		);
+	}
+
+	/**
+	 * Add admin notice if API key is unset.
+	 */
+	public static function activation_nag() {
+		$screen = get_current_screen();
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<?php
+					echo wp_kses_post(
+							// translators: urge users to input their API credentials on settings page.
+						__( 'Newspack Election Kit requires a Google Maps Geocoding API Key to function. You can obtain one for free following the instructions from <a href="https://developers.google.com/maps/documentation/geocoding/start" target="_blank">Google here</a>. Then please <a href="options-general.php?page=newspack-electionkit-settings-admin">go to settings</a> to input your key.', 'newspack-electionkit' )
+					);
+				?>
+			</p>
+		</div>
+		<?php
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a settings screen where Google Maps Geocoding API key can be input. Adds an admin notice if the the key has not yet been input. If the key is absent but the `wp-config.php` constant _is_ present the plugin falls back to the constant to avoid breakages after deploying this branch. The `README` has been updated accordingly.

### How to test the changes in this Pull Request:

1. Navigate to `Settings->Election Kit`. Verify page exists and loads properly.
2. Assuming the `wp-config.php` constant `NEWSPACK_ELECTIONKIT_GOOGLE_API_KEY` is set to a valid Google API key, observe the plugin continues to work without inputting a key in settings.
3. Observe there is an admin notice warning the user they must create and input the key.
4. Add a Google Maps API key in settings and save.
5. Verify the plugin continues to work properly.
6. Remove the constant from `wp-config.php`, observe the plugin continues to function properly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
