### PR TITLE
Update credit text sizing

### DIFF
--- a/src/electionkit.scss
+++ b/src/electionkit.scss
@@ -149,6 +149,11 @@
 	justify-content: center;
 }
 
+/* Credit */
+.newspack-electionkit .ek-credit {
+	font-size: 0.8em;
+}
+
 /* Error */
 .newspack-electionkit .ek-error {
 	color: red;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the sizing of the credit that appears below the search box, to make it feel more proportionate to the other elements in the plugin.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm that the credit text that appears below the search field is smaller, but still legible/looks good.

Before:

![image](https://user-images.githubusercontent.com/177561/95792926-545f6680-0c99-11eb-8144-e1d6ebe31692.png)

After:

![image](https://user-images.githubusercontent.com/177561/95792793-064a6300-0c99-11eb-9297-fad5e5b0edd1.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
