### PR TITLE
Add pot file for translating the plugin

### DIFF
--- a/electionkit.php
+++ b/electionkit.php
@@ -1,13 +1,14 @@
 <?php
 /**
- * Plugin Name: NewsPack Election Kit
+ * Plugin Name: Newspack Election Kit
  * Plugin URI: https://willenglishiv.com/newspack-election-kit
- * Description: Provides a sample ballot for NewsPack Customers.  Install on the page of your choice with the shortcode [sample_ballot]
+ * Description: Provides a sample ballot for Newspack Customers.  Install on the page of your choice with the shortcode [sample_ballot]
  * Author: Will English IV
  * Author URI: https://willenglishiv.com/
  * Version: 1.0.0
+ * Text Domain: newspack-electionkit
  *
- * @package NewsPack Election Kit
+ * @package Newspack Election Kit
  * @version 1.0.0
  */
 
@@ -32,12 +33,22 @@ function np_sample_ballot_form( $atts ) {
 			<label for="ek-address"><?php esc_html_e( "Enter the address where you're registered to vote:", 'newspack-electionkit' ); ?></label>
 			<span>
 				<input type="text" id="ek-address" name="ek-address" value="<?php echo esc_attr( $a['debug_location'] ); ?>" required>
-				<input type="submit" value="<?php esc_attr_e( 'Submit' ); ?>">
+				<input type="submit" value="<?php esc_attr_e( 'Submit', 'newspack-electionkit' ); ?>">
 			</span>
 		</form>
 		<div class="ek-credit">
 			<?php
-				_e( 'This sample ballot tool originated as a project of <a href="https://www.thechicagoreporter.com" target="_blank">The Chicago Reporter</a> and is provided with support from <a href="https://newspack.pub/" target="_blank">Newspack</a> and the <a href="https://www.americanpressinstitute.org/" target="_blank">American Press Institute</a>. Candidate data is sourced from <a href="https://ballotpedia.org/Main_Page" target="_blank">Ballotpedia</a>.', 'newspack-electionkit' );
+				$credit_allowed_html = array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+				);
+
+				echo wp_kses(
+					__( 'This sample ballot tool originated as a project of <a href="https://www.thechicagoreporter.com" target="_blank">The Chicago Reporter</a> and is provided with support from <a href="https://newspack.pub/" target="_blank">Newspack</a> and the <a href="https://www.americanpressinstitute.org/" target="_blank">American Press Institute</a>. Candidate data is sourced from <a href="https://ballotpedia.org/Main_Page" target="_blank">Ballotpedia</a>.', 'newspack-electionkit' ),
+					$credit_allowed_html
+				);
 			?>
 		</div>
 		<div class="spinner"><img alt="spinner" src="<?php echo esc_url( plugin_dir_url( __FILE__ ) . 'img/25.gif' ); ?>"></div>
@@ -65,7 +76,7 @@ function np_sample_ballot() {
 	if ( ! $google_api_key ) {
 		wp_send_json_error(
 			array(
-				'message' => __( 'No Google API key. Please add to wp-config file as described in plugin README.', 'newspack-electionkit' ),
+				'message' => esc_html__( 'No Google API key. Please add to wp-config file as described in plugin README.', 'newspack-electionkit' ),
 			)
 		);
 	}
@@ -111,7 +122,7 @@ function np_sample_ballot() {
 	if ( ! $in_the_united_states ) {
 		wp_send_json_error(
 			array(
-				'message'        => __( 'Address did not return a valid US location.', 'newspack-electionkit' ),
+				'message'        => esc_html__( 'Address did not return a valid US location.', 'newspack-electionkit' ),
 				'locationResult' => $location_result,
 			)
 		);
@@ -131,7 +142,7 @@ function np_sample_ballot() {
 	if ( is_wp_error( $bp_districts_request ) ) {
 		wp_send_json_error(
 			array(
-				'message' => __( "Ballotpedia sample ballot elections call didn't work.", 'newspack-electionkit' ),
+				'message' => esc_html__( "Ballotpedia sample ballot elections call didn't work.", 'newspack-electionkit' ),
 			)
 		);
 	} else {
@@ -143,7 +154,7 @@ function np_sample_ballot() {
 	if ( ! $bp_district_data ) {
 		wp_send_json_error(
 			array(
-				'message' => __( "Ballotpedia sample ballot elections didn't return any data.", 'newspack-electionkit' ),
+				'message' => esc_html__( "Ballotpedia sample ballot elections didn't return any data.", 'newspack-electionkit' ),
 			)
 		);
 	}
@@ -165,7 +176,7 @@ function np_sample_ballot() {
 	if ( is_wp_error( $bp_ballot_request ) ) {
 		wp_send_json_error(
 			array(
-				'message'     => __( "Ballotpedia sample ballot results call didn't work.", 'newspack-electionkit' ),
+				'message'     => esc_html__( "Ballotpedia sample ballot results call didn't work.", 'newspack-electionkit' ),
 				'information' => $bp_ballot_request,
 			)
 		);
@@ -178,7 +189,7 @@ function np_sample_ballot() {
 	if ( ! $bp_ballot_data ) {
 		wp_send_json_error(
 			array(
-				'message' => __( "Ballotpedia sample ballot results didn't return any data.", 'newspack-electionkit' ),
+				'message' => esc_html__( "Ballotpedia sample ballot results didn't return any data.", 'newspack-electionkit' ),
 			)
 		);
 	}

--- a/languages/newspack-electionkit.pot
+++ b/languages/newspack-electionkit.pot
@@ -1,0 +1,88 @@
+# Copyright (C) 2020 Will English IV
+# This file is distributed under the same license as the Newspack Election Kit plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: Newspack Election Kit 1.0.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/newspack-electionkit\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2020-10-14T20:43:37+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.4.0\n"
+"X-Domain: newspack-electionkit\n"
+
+#. Plugin Name of the plugin
+msgid "Newspack Election Kit"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://willenglishiv.com/newspack-election-kit"
+msgstr ""
+
+#. Description of the plugin
+msgid "Provides a sample ballot for Newspack Customers.  Install on the page of your choice with the shortcode [sample_ballot]"
+msgstr ""
+
+#. Author of the plugin
+msgid "Will English IV"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://willenglishiv.com/"
+msgstr ""
+
+#: electionkit.php:32
+msgid "Enter the address where you're registered to vote:"
+msgstr ""
+
+#: electionkit.php:35
+msgid "Submit"
+msgstr ""
+
+#: electionkit.php:48
+msgid "This sample ballot tool originated as a project of <a href=\"https://www.thechicagoreporter.com\" target=\"_blank\">The Chicago Reporter</a> and is provided with support from <a href=\"https://newspack.pub/\" target=\"_blank\">Newspack</a> and the <a href=\"https://www.americanpressinstitute.org/\" target=\"_blank\">American Press Institute</a>. Candidate data is sourced from <a href=\"https://ballotpedia.org/Main_Page\" target=\"_blank\">Ballotpedia</a>."
+msgstr ""
+
+#: electionkit.php:54
+msgid "There was an error retrieving the sample ballot.  Please try again later."
+msgstr ""
+
+#: electionkit.php:78
+msgid "No Google API key. Please add to wp-config file as described in plugin README."
+msgstr ""
+
+#: electionkit.php:124
+msgid "Address did not return a valid US location."
+msgstr ""
+
+#: electionkit.php:144
+msgid "Ballotpedia sample ballot elections call didn't work."
+msgstr ""
+
+#: electionkit.php:156
+msgid "Ballotpedia sample ballot elections didn't return any data."
+msgstr ""
+
+#: electionkit.php:178
+msgid "Ballotpedia sample ballot results call didn't work."
+msgstr ""
+
+#: electionkit.php:191
+msgid "Ballotpedia sample ballot results didn't return any data."
+msgstr ""
+
+#: electionkit.php:246
+#: electionkit.php:361
+msgid "Ballot Measures"
+msgstr ""
+
+#: electionkit.php:328
+msgid "Facebook"
+msgstr ""
+
+#: electionkit.php:340
+msgid "Twitter"
+msgstr ""


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a POT file for future translations of the plugin. 

### How to test the changes in this Pull Request:

1. Apply the plugin.
2. Install and activate the [Pig Latin](https://wordpress.org/plugins/piglatin/) plugin.
3. View on the front-end, and confirm that strings coming from the plugin (and not Ballotpedia) are changed into pig latin -- this indicates that they've been marked for translation correctly.

![image](https://user-images.githubusercontent.com/177561/96044094-c3b59180-0e24-11eb-9d11-b94b24f615d6.png)

![image](https://user-images.githubusercontent.com/177561/96044116-cb753600-0e24-11eb-9c2b-bcdf3c697935.png)

![image](https://user-images.githubusercontent.com/177561/96044146-d8922500-0e24-11eb-85e7-973b2815a68e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
