### PR TITLE
feat: updating ballotpedia api calls requiring api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Install using a shortcode ```[sample_ballot]```
 
 Has a dependency on Google API key for address, which can be set in Settings->Election Kit.
 
+Also has a dependency on a Ballotpedia API key for sample ballot results, which can be set in Settings->Election Kit.
+
 ## Development
 
 Run `composer update && npm install`.

--- a/includes/class-newspack-electionkit-settings.php
+++ b/includes/class-newspack-electionkit-settings.php
@@ -19,10 +19,13 @@ class Newspack_Electionkit_Settings {
 	 * Set up hooks.
 	 */
 	public static function init() {
-		add_action( 'admin_menu', [ __CLASS__, 'add_plugin_page' ] );
-		add_action( 'admin_init', [ __CLASS__, 'page_init' ] );
+		add_action( 'admin_menu', array( __CLASS__, 'add_plugin_page' ) );
+		add_action( 'admin_init', array( __CLASS__, 'page_init' ) );
 		if ( ! get_option( 'newspack_electionkit_google_api_key', null ) ) {
-			add_action( 'admin_notices', [ __CLASS__, 'activation_nag' ] );
+			add_action( 'admin_notices', array( __CLASS__, 'activation_nag' ) );
+		}
+		if ( ! get_option( 'newspack_electionkit_ballotpedia_api_key', null ) ) {
+			add_action( 'admin_notices', array( __CLASS__, 'activation_nag_ballotpedia' ) );
 		}
 	}
 
@@ -35,7 +38,7 @@ class Newspack_Electionkit_Settings {
 			__( 'Election Kit', 'newspack-electionkit' ),
 			'manage_options',
 			'newspack-electionkit-settings-admin',
-			[ __CLASS__, 'create_admin_page' ]
+			array( __CLASS__, 'create_admin_page' )
 		);
 	}
 
@@ -46,7 +49,7 @@ class Newspack_Electionkit_Settings {
 
 		?>
 		<div class="wrap">
-			<h1><?php _e( 'Election Kit Settings', 'newspack-electionkit' ); ?></h1>
+			<h1><?php esc_html_e( 'Election Kit Settings', 'newspack-electionkit' ); ?></h1>
 			<form method="post" action="options.php">
 			<?php
 				settings_fields( 'newspack_electionkit_options_group' );
@@ -75,7 +78,20 @@ class Newspack_Electionkit_Settings {
 		add_settings_field(
 			'newspack_electionkit_google_api_key',
 			__( 'Google Maps', 'newspack-electionkit' ),
-			[ __CLASS__, 'newspack_electionkit_google_api_key_callback' ],
+			array( __CLASS__, 'newspack_electionkit_google_api_key_callback' ),
+			'newspack-electionkit-settings-admin',
+			'newspack_electionkit_settings'
+		);
+
+		register_setting(
+			'newspack_electionkit_options_group',
+			'newspack_electionkit_ballotpedia_api_key'
+		);
+
+		add_settings_field(
+			'newspack_electionkit_ballotpedia_api_key',
+			__( 'Ballotpedia', 'newspack-electionkit' ),
+			array( __CLASS__, 'newspack_electionkit_ballotpedia_api_key_callback' ),
 			'newspack-electionkit-settings-admin',
 			'newspack_electionkit_settings'
 		);
@@ -94,6 +110,18 @@ class Newspack_Electionkit_Settings {
 	}
 
 	/**
+	 * Render Ballotpedia Debug Checkbox.
+	 */
+	public static function newspack_electionkit_ballotpedia_api_key_callback() {
+		$newspack_electionkit_ballotpedia_api_key = get_option( 'newspack_electionkit_ballotpedia_api_key', false );
+		printf(
+			'<input type="text" id="newspack_electionkit_ballotpedia_api_key" name="newspack_electionkit_ballotpedia_api_key" aria-describedby="newspack_electionkit_ballotpedia_api_key-description" value="%s" class="regular-text"/><p class="description" id="newspack_electionkit_ballotpedia_api_key-description">%s</p>',
+			esc_attr( $newspack_electionkit_ballotpedia_api_key ),
+			esc_html( 'This plugin requires a valid Ballotpedia API key. Please contact your Technical Account manager at Newspack for access.' )
+		);
+	}
+
+	/**
 	 * Add admin notice if API key is unset.
 	 */
 	public static function activation_nag() {
@@ -106,6 +134,25 @@ class Newspack_Electionkit_Settings {
 							// translators: urge users to input their API credentials on settings page.
 						__( 'Newspack Election Kit requires a Google Maps Geocoding API Key to function. You can obtain one for free following the instructions from <a href="https://developers.google.com/maps/documentation/geocoding/start" target="_blank">Google here</a>. Then please <a href="options-general.php?page=newspack-electionkit-settings-admin">go to settings</a> to input your key.', 'newspack-electionkit' )
 					);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Add admin notice if the Ballotpedia API key is unset.
+	 */
+	public static function activation_nag_ballotpedia() {
+		$screen = get_current_screen();
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<?php
+				echo wp_kses_post(
+				// translators: urge users to input their API credentials on settings page.
+					__( 'Newspack Election Kit requires a Ballotpedia API Key to function. Please contact your Technical Account Manager to obtain one. Then please <a href="options-general.php?page=newspack-electionkit-settings-admin">go to settings</a> to input your key.', 'newspack-electionkit' )
+				);
 				?>
 			</p>
 		</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ballotpedia is deprecating API endpoints, also now requires an API key to work.
Added a Ballotpedia API key in the options panel
Updated the GET requests to include the API key as part of the request per Ballotpedia API spec.
Updated documentation to reflect new change.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Update the plugin code
2. Add a Ballotpedia API Key to Settings->Election Kit
3. Observe getting a Sample Ballot with the shortcode.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
