### PR TITLE
fix: rename plugin entry point

### DIFF
--- a/newspack-electionkit.php
+++ b/newspack-electionkit.php
@@ -9,7 +9,7 @@
  * Text Domain: newspack-electionkit
  *
  * @package Newspack Election Kit
- * @version 1.0.0
+ * @version 0.0.0
  */
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Renames the plugin entry point to `newspack-electionkit.php`, to match the plugin name and resolve an issue where automated release did not correctly set the version number in the plugin file.

### How to test the changes in this Pull Request:

There should be no functional changes. Simply install from this branch and verify the plugin works as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
